### PR TITLE
Add project docs and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# BossMyHustle Repository Guidelines
+
+This file applies to the entire repository.
+
+## Development
+- Keep the feature list in `README.md` up to date for every module.
+- Document new modules and significant changes.
+- Verify endpoints and usage against the official OnlyFans API documentation.
+- Avoid committing secrets such as API keys or passwords.
+- Use black, white, and gray with rose highlights for any front-end styling.
+- Ensure the front end reflects background activity (API calls, errors, etc.).
+
+## Testing
+- Run `npm test` and `npm run lint` if available.
+- Run any PHP test suites (e.g., `composer test`) when present.
+- If a script is missing, still run the command and record the output.
+
+## Commit Messages
+- Use imperative mood and limit the subject line to 50 characters.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# bossyourhustle
+# BossMyHustle OF Tool Box
+
+A multi-module platform for managing OnlyFans accounts. Each module interacts
+with the OnlyFans API and webhooks to help creators automate and monitor their
+accounts.
+
+## Project Overview
+- Modular design; modules intertwine as the project grows.
+- Front-end and back-end are equally important. User experience should always
+  indicate background activity and surface clear error messages.
+- Uses the OnlyFans API and OpenAPI.
+- Initial setup includes a simple PHP login to prevent unauthorized access.
+
+## Environment
+- **Domain:** [bossyourhustle.com](http://bossyourhustle.com)
+- **Server:** Plesk with Cloudflare tunnel and DNS.
+- **Node.js:** 22.18.0
+- **PHP:** 8.2.29 (FPM/FastCGI)
+- **Database:** `byhdb_` on `localhost:3306` with user `carbide` (password
+  managed outside the repo).
+
+## Modules and Features
+| Module | Description |
+| ------ | ----------- |
+| Authentication | Simple PHP login to restrict access. |
+
+_Add new modules to this table as the project expands._
+
+## Style
+The UI color scheme should be black, white, and gray with rose highlights.
+
+## OnlyFans API Resources
+- Review the [Quickstart](https://onlyfansapi.com/introduction/quickstart) for API key creation and account connection.
+- Understand the [Credit System](https://onlyfansapi.com/introduction/essentials/credits) and [Rate Limits](https://onlyfansapi.com/introduction/essentials/rate-limits).
+- Learn the [Response Structure](https://onlyfansapi.com/introduction/essentials/response-structure) and [Proxies](https://onlyfansapi.com/introduction/essentials/proxies).
+- See guides for [Composing Posts](https://onlyfansapi.com/introduction/guides/composing-posts), [Composing Messages](https://onlyfansapi.com/introduction/guides/composing-messages), [Uploading Media](https://onlyfansapi.com/introduction/guides/uploading-media), and [Text Formatting](https://onlyfansapi.com/introduction/guides/text-formatting).
+- Always consult the official OnlyFansAPI.com documentation for up-to-date endpoints and usage details.
+
+## Contributing
+1. Keep documentation, including this README, up to date.
+2. Run tests (`npm test`, `npm run lint`, `composer test`) when available.
+3. Use clear, descriptive commit messages.


### PR DESCRIPTION
## Summary
- link to OnlyFans API docs for quickstart, usage, and guides in README
- add guideline to verify endpoints against official OnlyFans documentation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689828262c048321b7f5a1550e06402a