### PR TITLE
Add themed index page with auth gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ OnlyFansAPI.com documentation before implementing calls.**
 | Module | Description |
 | ------ | ----------- |
 | Authentication | Node.js signup/login with SQLite and admin seeding. |
+| Landing Page | Authenticated index with themed UI and session status. |
 
 _Add new modules to this table as the project expands._
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Boss Your Hustle OF Tool Box</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <h1>Boss Your Hustle OF Tool Box</h1>
+  <p id="welcome"></p>
+  <p class="message" id="msg"></p>
+  <a href="/logout">Logout</a>
+  <script>
+    fetch('/session')
+      .then(res => res.json())
+      .then(data => {
+        if (data.user) {
+          document.getElementById('welcome').textContent = `Welcome, ${data.user.username}!`;
+        }
+      })
+      .catch(() => {
+        document.getElementById('msg').textContent = 'Error loading session';
+      });
+
+    const params = new URLSearchParams(window.location.search);
+    const message = params.get('message');
+    if (message) document.getElementById('msg').textContent = message;
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const session = require('express-session');
 const bcrypt = require('bcrypt');
+const path = require('path');
 const { db, init } = require('./db');
 
 const app = express();
@@ -14,7 +15,6 @@ app.use(session({
   resave: false,
   saveUninitialized: false
 }));
-app.use(express.static('public'));
 
 const requireAuth = (req, res, next) => {
   if (!req.session.user) {
@@ -23,23 +23,15 @@ const requireAuth = (req, res, next) => {
   next();
 };
 
-app.get('/', (req, res) => {
-  const user = req.session.user;
-  const message = req.query.message || '';
-  res.send(`<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8" />
-<title>Boss Your Hustle OF Tool Box</title>
-<link rel="stylesheet" href="/style.css" />
-</head>
-<body>
-<h1>Boss Your Hustle OF Tool Box</h1>
-${user ? `<p>Welcome, ${user.username}!</p><a href="/logout">Logout</a>` : `<a href="/signup.html">Sign Up</a> | <a href="/login.html">Login</a>`}
-<p class="message">${message}</p>
-</body>
-</html>`);
+app.get(['/', '/index.html'], requireAuth, (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
+
+app.get('/session', (req, res) => {
+  res.json({ user: req.session.user || null });
+});
+
+app.use(express.static('public'));
 
 app.post('/signup', (req, res) => {
   const { username, password } = req.body;


### PR DESCRIPTION
## Summary
- protect index route with session check
- serve static index page styled in black, white, and rose
- expose session endpoint and document landing page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689832721ae0832198c95c07cb7c92e2