### PR TITLE
Add messaging route for OnlyFans API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ OnlyFansAPI.com documentation before implementing calls.**
 | ------ | ----------- |
 | Authentication | Node.js signup/login with SQLite and admin seeding. |
 | Landing Page | Authenticated index with themed UI and session status. |
+| Messaging | Send OnlyFans messages via API with status feedback. |
 
 _Add new modules to this table as the project expands._
 

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const PORT = process.env.PORT || 3000;
 init();
 
 app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 app.use(session({
   secret: 'bossyourhustle-secret',
   resave: false,
@@ -64,6 +65,37 @@ app.get('/logout', requireAuth, (req, res) => {
   req.session.destroy(() => {
     res.redirect('/?message=Logged%20out');
   });
+});
+
+app.post('/send-message', requireAuth, async (req, res) => {
+  const { message, recipientId } = req.body;
+  if (!message || !recipientId) {
+    return res.status(400).json({ success: false, error: 'Missing fields' });
+  }
+  const apiKey = process.env.ONLYFANS_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ success: false, error: 'API key not configured' });
+  }
+  try {
+    const response = await fetch('https://api.onlyfansapi.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({ message, recipientId })
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      return res
+        .status(response.status)
+        .json({ success: false, error: errText });
+    }
+    const data = await response.json();
+    res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: 'Server error' });
+  }
 });
 
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add POST /send-message route to dispatch OnlyFans messages
- parse JSON bodies and handle API authentication and errors
- document new messaging module in README

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_689861ddea1c8321a905e2b51cfaef2f