### PR TITLE
Add env example and broaden gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=carbide
+DB_PASS=REPLACE_ME
+DB_NAME=byhdb_
+SESSION_SECRET=REPLACE_ME
+
+# Optional defaults for local dev only; DO NOT commit real keys
+ONLYFANS_API_KEY=
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
-node_modules
+# Node
+node_modules/
+npm-debug.log*
+yarn.lock
+pnpm-lock.yaml
+
+# Env & runtime
+.env
+.env.*
+!.env.example
 *.sqlite
-npm-debug.log
+*.log
+pids/
+coverage/
+dist/
+build/
+
+# Plesk artifacts
+*.zip
+*.tar

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ OnlyFansAPI.com documentation before implementing calls.**
 - **PHP:** 8.2.29 (FPM/FastCGI)
 - **Database:** `byhdb_` on `localhost:3306` with user `carbide` (password
   managed outside the repo).
+- Copy `.env.example` to `.env` and replace placeholders with real values.
 
 ## Modules and Features
 | Module | Description |


### PR DESCRIPTION
## Summary
- expand .gitignore to cover env and build artifacts while keeping .env.example tracked
- provide .env.example with safe placeholders
- document env template usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a9f4044188321984ee805f9511d51